### PR TITLE
New and modified routes for Places and Lists

### DIFF
--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -1043,6 +1043,189 @@ paths:
           description: 'No Content'
           headers: {}
       deprecated: false
+  /account/list:
+    get:
+      tags:
+        - List
+      summary: Retrieve all of a user's lists
+      security:
+        - bearerAuth: []
+      operationId: AccountGetUserLists
+      parameters: []
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                [{
+                  "_id": "690197296ff",
+                  "name": "My First List",
+                  "places": ["ChIJy4PlpUCBhYA"]
+                }]
+          headers: {}
+      deprecated: false
+    post:
+      tags:
+        - List
+      summary: Create new List
+      security:
+        - bearerAuth: []
+      operationId: CreateList
+      parameters: []
+      requestBody:
+        description: ''
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountListRequestBody'
+            example: |
+              {
+                "name": "List name or title"
+              }
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                {
+                  "_id": "69025351b26731",
+                  "userId": "67fd2f5ebede3",
+                  "name": "List name or title",
+                  "places": [],
+                  "createdAt": "2025-10-29T17:48:01.681Z",
+                  "updatedAt": "2025-10-29T17:48:01.681Z"
+                }
+          headers: {}
+      deprecated: false
+  /account/list/{listId}:
+    parameters:
+      - in: path
+        name: listId
+        schema:
+          type: string
+          example: list-id-sdfsd
+        required: true
+        description: The list ID
+    get:
+      tags:
+        - List
+      summary: Retrieve a list details along with the associated place's details
+      security:
+        - bearerAuth: []
+      operationId: AccountGetListWithPlaces
+      parameters: []
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                {
+                  "_id": "690197296ff3",
+                  "userId": "67fd2f5ebed",
+                  "name": "List name or title",
+                  "places": [{
+                    "_id": "68f2b8ecd5a99",
+                    "placeId": "ChIJy4PlpUCB",
+                    "address": "Pier 7, San Francisco",
+                    "country": "United States",
+                    "iconBackground": "#7B9EB0",
+                    "iconURL": "https://maps.gstatic.com/mapfiles/place_api/icons/v2/generic_pinlet",
+                    "imageURL": "http://example.com/media_ayjj8q.jpg",
+                    "location": [37.80006, -122.394391],
+                    "name": "Pier 7 Vista Point",
+                    "rating": 4.9,
+                    "reviewSummary": "lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                    "state": "California",
+                    "summary": "Scenic, pedestrian-friendly pier offering sweeping views of the bay, plus fishing and benches.",
+                    "type": "",
+                    "userRatingCount": 114
+                  }],
+                  "createdAt": "2025-10-29T04:25:13.359Z",
+                  "updatedAt": "2025-10-29T17:40:03.821Z"
+                }
+          headers: {}
+      deprecated: false
+    delete:
+      tags:
+        - List
+      summary: Delete a list
+      security:
+        - bearerAuth: []
+      operationId: AccountDeleteList
+      parameters: []
+      responses:
+        '204':
+          description: 'No Content'
+          headers: {}
+      deprecated: false
+  /account/list/{listId}/{placeId}:
+    parameters:
+      - in: path
+        name: listId
+        schema:
+          type: string
+          example: list-id-sdfsd
+        required: true
+        description: The list ID
+      - in: path
+        name: placeId
+        schema:
+          type: string
+          example: google-place-id-sdfsd
+        required: true
+        description: The place ID
+    post:
+      tags:
+        - List
+      summary: Add a place to a list
+      security:
+        - bearerAuth: []
+      operationId: AccountAddPlaceToList
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                {
+                  "_id": "690197296ff3",
+                  "userId": "67fd2f5ebed",
+                  "name": "Second List",
+                  "places": ["ChIJy4PlpUCBh"],
+                  "createdAt": "2025-10-29T04:25:13.359Z",
+                  "updatedAt": "2025-10-29T18:00:26.614Z"
+                }
+          headers: {}
+      deprecated: false
+    delete:
+      tags:
+        - List
+      summary: Delete a place from a list
+      security:
+        - bearerAuth: []
+      operationId: AccountDeletePlaceFromList
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                {
+                  "_id": "690197296ff3",
+                  "userId": "67fd2f5ebed",
+                  "name": "Second List",
+                  "places": ["ChIJy4PlpUCBh"],
+                  "createdAt": "2025-10-29T04:25:13.359Z",
+                  "updatedAt": "2025-10-29T18:00:26.614Z"
+                }
+          headers: {}
+      deprecated: false
 components:
   securitySchemes:
     bearerAuth:
@@ -1106,6 +1289,14 @@ components:
           description: The image file to upload
       required:
         - image
+    AccountListRequestBody:
+      title: List's Object
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
     AccountPlanRequestBody:
       title: Plan's Object
       required:

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -182,7 +182,9 @@ paths:
                       "state": "California",
                       "summary": "lorem ipsum dolor sit amet, consectetur adipiscing elit",
                       "type": "event_venue",
-                      "userRatingCount": 25183
+                      "userRatingCount": 25183,
+                      "directionGoogleURI": "https://www.google.com/maps/dir/?asdasd",
+                      "placeGoogleURI": "https://www.google.com/maps/place/?q=place-id-sdfsdf"
                     }
                   ],
                   "isBookmarked": false
@@ -472,7 +474,9 @@ paths:
                   "reviewSummary": "lorem ipsum dolor sit amet, consectetur adipiscing elit",
                   "state": "California",
                   "summary": "lorem ipsum dolor sit amet, consectetur adipiscing elit",
-                  "userRatingCount": 2518
+                  "userRatingCount": 2518,
+                  "directionGoogleURI": "https://www.google.com/maps/dir/?asdasd",
+                  "placeGoogleURI": "https://www.google.com/maps/place/?q=place-id-sdfsdf"
                 }
           headers: {}
       deprecated: false

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -444,43 +444,6 @@ paths:
                 }
           headers: {}
       deprecated: false
-  /places/fetch/{googlePlaceId}:
-    parameters:
-      - in: path
-        name: googlePlaceId
-        schema:
-          type: string
-          example: google-place-id-sdfsdf
-        required: true
-        description: The Google place ID
-    get:
-      tags:
-        - Places
-      summary: Get json data fetched from google places api by the place id
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              example: |
-                {
-                  "placeId": "google-place-id-sdfsdf",
-                  "name": "Morcom Rose Garden",
-                  "state": "California",
-                  "country": "United States",
-                  "imageURL": "http://example.com/media_dtznfo.jpg",
-                  "address": "700 Jean St, Oakland",
-                  "location": [37.82001, -122.24656],
-                  "type": "garden",
-                  "iconURL": "https://maps.gstatic.com/mapfiles/place_api/icons/v2/tree_pinlet",
-                  "iconBackground": "#4DB546",
-                  "summary": "lorem ipsum dolor sit amet, consectetur adipiscing elit",
-                  "reviewSummary": "lorem ipsum dolor sit amet, consectetur adipiscing elit",
-                  "rating": 4.7,
-                  "userRatingCount": 954
-                }
-          headers: {}
-      deprecated: false
   /auth/register:
     post:
       tags:

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -9,6 +9,70 @@ servers:
   - url: https://ii-practicum-team-5-back-1.onrender.com/api/v1
     variables: {}
 paths:
+  /all:
+    get:
+      tags:
+        - Plans
+        - Places
+      summary: Get All Plans and Places, filter by geo location bounding box
+      operationId: GetAllPoints
+      parameters:
+        - $ref: '#/components/parameters/LatMin'
+        - $ref: '#/components/parameters/LngMin'
+        - $ref: '#/components/parameters/LatMax'
+        - $ref: '#/components/parameters/LngMax'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                {
+                  "count": 2,
+                  "items": [
+                    {
+                      "type": "plan",
+                      "item": {
+                        "_id": "68f184f82b5869008428d70a",
+                        "userId": {
+                          "_id": "67fd2f5ebede3059343fae72",
+                          "name": "John Doe"
+                        },
+                        "title": "UC Berkeley Neighborhood",
+                        "images": [
+                          "http://example.com/b6ptxwdn1uiykfhubuy5.jpg"
+                        ],
+                        "cities": [
+                          {
+                            "placeId": "ChIJ00mFOjZ5hYARk-l1ppUV6pQ",
+                            "name": "Berkeley, CA, USA"
+                          }
+                        ],
+                        "stopCount": 14,
+                        "rate": 4.5,
+                        "reviewCount": 183,
+                        "distance": 7.2,
+                        "duration": 6.5,
+                        "startLocation": [37.8697, -122.2675],
+                        "isBookmarked": false
+                      }
+                    },
+                    {
+                      "type": "place",
+                      "item": {
+                        "_id": "68f1855cd5a998699dc5fd73",
+                        "placeId": "ChIJoXC4GD59hYAR1RH0OwVhx1M",
+                        "iconBackground": "#13B5C7",
+                        "iconURL": "http://maps.gstatic.com/mapfiles/place_api/icons/v2/generic_pinlet",
+                        "location": [37.869338, -122.2613],
+                        "name": "Zellerbach Playhouse",
+                        "type": "performing_arts_theater"
+                      }
+                    }
+                  ]
+                }
+          headers: {}
+      deprecated: false
   /plans:
     get:
       tags:

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import favicon from 'express-favicon'
 import logger from 'morgan'
 import router from './routes/mainRouter'
 import authRouter from './routes/auth'
+import allNearbyRouter from './routes/allNearby'
 import plansRouter from './routes/plans'
 import placesRouter from './routes/places'
 import accountRouter from './routes/account'
@@ -30,6 +31,7 @@ app.use(favicon(__dirname + '/public/favicon.ico'))
 
 // routes
 app.use('/api/v1', express.json(), router)
+app.use('/api/v1/all', express.json(), allNearbyRouter)
 app.use('/api/v1/plans', express.json(), optionalAuthMiddleware, plansRouter)
 app.use('/api/v1/places', express.json(), optionalAuthMiddleware, placesRouter)
 app.use('/api/v1/auth', express.json(), authRouter)

--- a/src/controllers/account/lists.ts
+++ b/src/controllers/account/lists.ts
@@ -1,0 +1,131 @@
+import { Request, Response } from 'express'
+import ListSchema, { IList } from '../../models/Lists'
+import UnauthenticatedError from '../../errors/unauthentication_error'
+import { StatusCodes } from 'http-status-codes'
+import CustomAPIError from '../../errors/custom_error'
+import { Types } from 'mongoose'
+import NotFoundError from '../../errors/not_found'
+
+const fetchLists = async (req: Request, res: Response) => {
+  console.log('fetchLists')
+  if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
+
+  const filters = {
+    userId: req.user.userId,
+  }
+
+  const lists = await ListSchema.find(filters).select('name places').lean()
+
+  res.status(StatusCodes.OK).json(lists)
+}
+
+const fetchAList = async (req: Request, res: Response) => {
+  console.log('fetchAList')
+  if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
+
+  const userId = req.user.userId
+  const listId = req.params.listId
+
+  const filters = {
+    userId,
+    _id: new Types.ObjectId(listId),
+  }
+
+  const listWithPlaces = await ListSchema.findOne(filters)
+    .populate({ path: 'places', model: 'Place', localField: 'places', foreignField: 'placeId' })
+    .lean()
+
+  if (!listWithPlaces) throw new NotFoundError(`No list with id ${listId}`)
+
+  res.status(StatusCodes.OK).json(listWithPlaces)
+}
+
+const createNewList = async (req: Request, res: Response) => {
+  console.log('createNewList')
+  if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
+
+  const userId: string = req.user.userId
+  let { name } = req.body
+
+  const createdList: IList = await ListSchema.create({
+    name,
+    userId,
+  })
+
+  if (!createdList) throw new CustomAPIError('Failed to create new list', StatusCodes.INTERNAL_SERVER_ERROR)
+
+  res.status(StatusCodes.CREATED).json(createdList.toJSON())
+}
+
+const removeList = async (req: Request, res: Response) => {
+  console.log('removeList')
+  if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
+
+  const userId: string = req.user.userId
+  let { listId } = req.params
+
+  const result = await ListSchema.findByIdAndDelete({
+    _id: listId,
+    userId,
+  })
+
+  if (!result) {
+    throw new NotFoundError(`No list with id ${listId}`)
+  }
+
+  res.status(StatusCodes.NO_CONTENT).end()
+}
+
+const addPlaceToList = async (req: Request, res: Response) => {
+  console.log('addPlaceToList')
+  if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
+
+  const userId: string = req.user.userId
+  const { listId, placeId } = req.params
+
+  const updatedList: IList | null = await ListSchema.findOneAndUpdate(
+    {
+      _id: listId,
+      userId,
+    },
+    {
+      $addToSet: { places: placeId },
+    },
+    {
+      new: true,
+      runValidators: true,
+    }
+  )
+
+  if (!updatedList) throw new CustomAPIError('Failed to add place to the list', StatusCodes.INTERNAL_SERVER_ERROR)
+
+  res.status(StatusCodes.CREATED).json(updatedList.toJSON())
+}
+
+const removePlaceFromList = async (req: Request, res: Response) => {
+  console.log('removePlaceFromList')
+  if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
+
+  const userId: string = req.user.userId
+  const { listId, placeId } = req.params
+
+  const updatedList: IList | null = await ListSchema.findOneAndUpdate(
+    {
+      _id: listId,
+      userId,
+    },
+    {
+      $pull: { places: placeId },
+    },
+    {
+      new: true,
+      runValidators: true,
+    }
+  )
+
+  if (!updatedList) throw new CustomAPIError('Failed to remove place from the list', StatusCodes.INTERNAL_SERVER_ERROR)
+
+  res.status(StatusCodes.CREATED).json(updatedList.toJSON())
+}
+
+export { fetchLists, fetchAList, createNewList, removeList, addPlaceToList, removePlaceFromList }

--- a/src/controllers/account/lists.ts
+++ b/src/controllers/account/lists.ts
@@ -13,7 +13,6 @@ type ListWithPlaces = Omit<IList, 'places'> & {
 }
 
 const fetchLists = async (req: Request, res: Response) => {
-  console.log('fetchLists')
   if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
 
   const filters = {
@@ -26,7 +25,6 @@ const fetchLists = async (req: Request, res: Response) => {
 }
 
 const fetchAList = async (req: Request, res: Response) => {
-  console.log('fetchAList')
   if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
 
   const userId = req.user.userId
@@ -57,7 +55,6 @@ const fetchAList = async (req: Request, res: Response) => {
 }
 
 const createNewList = async (req: Request, res: Response) => {
-  console.log('createNewList')
   if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
 
   const userId: string = req.user.userId
@@ -74,7 +71,6 @@ const createNewList = async (req: Request, res: Response) => {
 }
 
 const removeList = async (req: Request, res: Response) => {
-  console.log('removeList')
   if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
 
   const userId: string = req.user.userId
@@ -93,7 +89,6 @@ const removeList = async (req: Request, res: Response) => {
 }
 
 const addPlaceToList = async (req: Request, res: Response) => {
-  console.log('addPlaceToList')
   if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
 
   const userId: string = req.user.userId
@@ -119,7 +114,6 @@ const addPlaceToList = async (req: Request, res: Response) => {
 }
 
 const removePlaceFromList = async (req: Request, res: Response) => {
-  console.log('removePlaceFromList')
   if (!req.user) throw new UnauthenticatedError('Not authorized to access.')
 
   const userId: string = req.user.userId

--- a/src/controllers/allNearby.ts
+++ b/src/controllers/allNearby.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express'
+import { StatusCodes } from 'http-status-codes'
+import PlanSchema from '../models/Plans'
+import PlaceSchema from '../models/Places'
+import { geoJsonToCoords } from '../utils/location'
+import { attachBookmarkFlagToPlans } from './util'
+
+const PLANS_MAX_LIMIT = 20
+const PLACES_MAX_LIMIT = 40
+
+const fetchAllNearby = async (req: Request, res: Response) => {
+  const { latmin, lngmin, latmax, lngmax } = req.query
+
+  const withinBoundingBox = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [lngmin, latmin],
+        [lngmin, latmax],
+        [lngmax, latmax],
+        [lngmax, latmin],
+        [lngmin, latmin], // close the square
+      ],
+    ],
+  }
+
+  const plans = await PlanSchema.find({
+    startLocation: {
+      $geoWithin: {
+        $geometry: withinBoundingBox,
+      },
+    },
+  })
+    .limit(PLANS_MAX_LIMIT)
+    .select('title images cities stopCount type rate reviewCount startLocation distance duration')
+    .populate('userId', 'name')
+    .lean()
+
+  const authenticatedUserId = req.user ? req.user.userId : ''
+  const plansWithBookmarksStatus = await attachBookmarkFlagToPlans(plans, authenticatedUserId)
+
+  const places = await PlaceSchema.find({
+    location: {
+      $geoWithin: {
+        $geometry: withinBoundingBox,
+      },
+    },
+  })
+    .select('placeId name location type iconURL iconBackground')
+    .limit(PLACES_MAX_LIMIT)
+    .lean()
+
+  res.status(StatusCodes.OK).json({
+    count: plansWithBookmarksStatus.length + places.length,
+    items: [
+      ...plansWithBookmarksStatus.map((item) => ({
+        type: 'plan',
+        item: {
+          ...item,
+          startLocation: geoJsonToCoords(item.startLocation),
+        },
+      })),
+      ...places.map((item) => ({
+        type: 'place',
+        item: {
+          ...item,
+          location: geoJsonToCoords(item.location),
+        },
+      })),
+    ],
+  })
+}
+
+export { fetchAllNearby }

--- a/src/controllers/places.ts
+++ b/src/controllers/places.ts
@@ -26,12 +26,69 @@ const fetchPlace = async (req: Request, res: Response) => {
     )
     .lean()
 
-  if (!place) throw new CustomAPIError(`No place with id ${placeId}`, StatusCodes.NOT_FOUND)
+  if (place) {
+    res.status(StatusCodes.OK).json({
+      ...place,
+      location: geoJsonToCoords(place.location),
+    })
+  } else {
+    // Check if the place is already in our db
+    const existingPlace: IGooglePlace | null = await GooglePlaceSchema.findOne({
+      googlePlaceId: placeId,
+      version: GOOGLE_PLACE_FETCH_VERSION,
+    }).lean()
+    if (existingPlace) {
+      const data = JSON.parse(existingPlace.data)
+      res.status(StatusCodes.OK).json(transformGooglePlaceToSchema(data))
+    } else {
+      const apiKey = process.env.GOOGLE_MAPS_API_KEY as string
+      if (!apiKey)
+        throw new CustomAPIError('Google Places API key is not configured', StatusCodes.INTERNAL_SERVER_ERROR)
+      const fields =
+        'id,displayName,shortFormattedAddress,formattedAddress,addressComponents,location,icon_mask_base_uri,photos,primaryType,iconBackgroundColor,editorialSummary,generativeSummary,reviewSummary,rating,userRatingCount'
+      const url = `https://places.googleapis.com/v1/places/${placeId}?fields=${fields}&key=${apiKey}`
 
-  res.status(StatusCodes.OK).json({
-    ...place,
-    location: geoJsonToCoords(place.location),
-  })
+      const response = await fetch(url)
+      if (response.ok) {
+        const data = await response.json()
+
+        if (data.photos.length > 0) {
+          // if exist get maximum 4 images and store it in Cloudinary
+          for (let i = 0; i < data.photos.length && i < PLACE_IMG_UPLOAD_MAX_COUNT; i++) {
+            if ('name' in data.photos[i]) {
+              const imageURL = `https://places.googleapis.com/v1/${data.photos[i].name}/media?maxHeightPx=400&maxWidthPx=400&key=${process.env.GOOGLE_MAPS_API_KEY}`
+              const { secure_url } = await cloudinary.uploader.upload(imageURL, {
+                folder: 'ZipTrip/Places',
+                overwrite: true,
+                invalidate: true,
+              })
+              data.photos[i].imageURL = secure_url
+            }
+          }
+        }
+
+        // Insert if placeId not found
+        // Update if version was different
+        await GooglePlaceSchema.updateOne(
+          {
+            googlePlaceId: placeId,
+            version: { $ne: GOOGLE_PLACE_FETCH_VERSION },
+          },
+          {
+            $set: {
+              version: GOOGLE_PLACE_FETCH_VERSION,
+              data: JSON.stringify(data),
+            },
+          },
+          { upsert: true }
+        )
+        res.status(StatusCodes.OK).json(transformGooglePlaceToSchema(data))
+      } else {
+        throw new CustomAPIError('Failed to fetch place from Google Places API', StatusCodes.INTERNAL_SERVER_ERROR)
+      }
+    }
+    // res.status(StatusCodes.OK).json({ googlePlaceId: placeId })
+  }
 }
 
 const fetchAllNearbyPlaces = async (req: Request, res: Response) => {
@@ -73,63 +130,4 @@ const fetchAllNearbyPlaces = async (req: Request, res: Response) => {
   })
 }
 
-const fetchGooglePlace = async (req: Request, res: Response) => {
-  // Check if the place is already in our db
-  const { googlePlaceId } = req.params
-  const existingPlace: IGooglePlace | null = await GooglePlaceSchema.findOne({
-    googlePlaceId,
-    version: GOOGLE_PLACE_FETCH_VERSION,
-  }).lean()
-  if (existingPlace) {
-    const data = JSON.parse(existingPlace.data)
-    res.status(StatusCodes.OK).json(transformGooglePlaceToSchema(data))
-  } else {
-    const apiKey = process.env.GOOGLE_MAPS_API_KEY as string
-    if (!apiKey) throw new CustomAPIError('Google Places API key is not configured', StatusCodes.INTERNAL_SERVER_ERROR)
-    const fields =
-      'id,displayName,shortFormattedAddress,formattedAddress,addressComponents,location,icon_mask_base_uri,photos,primaryType,iconBackgroundColor,editorialSummary,generativeSummary,reviewSummary,rating,userRatingCount'
-    const url = `https://places.googleapis.com/v1/places/${googlePlaceId}?fields=${fields}&key=${apiKey}`
-
-    const response = await fetch(url)
-    if (response.ok) {
-      const data = await response.json()
-
-      if (data.photos.length > 0) {
-        // if exist get maximum 4 images and store it in Cloudinary
-        for (let i = 0; i < data.photos.length && i < PLACE_IMG_UPLOAD_MAX_COUNT; i++) {
-          if ('name' in data.photos[i]) {
-            const imageURL = `https://places.googleapis.com/v1/${data.photos[i].name}/media?maxHeightPx=400&maxWidthPx=400&key=${process.env.GOOGLE_MAPS_API_KEY}`
-            const { secure_url } = await cloudinary.uploader.upload(imageURL, {
-              folder: 'ZipTrip/Places',
-              overwrite: true,
-              invalidate: true,
-            })
-            data.photos[i].imageURL = secure_url
-          }
-        }
-      }
-
-      // Insert if placeId not found
-      // Update if version was different
-      await GooglePlaceSchema.updateOne(
-        {
-          googlePlaceId,
-          version: { $ne: GOOGLE_PLACE_FETCH_VERSION },
-        },
-        {
-          $set: {
-            version: GOOGLE_PLACE_FETCH_VERSION,
-            data: JSON.stringify(data),
-          },
-        },
-        { upsert: true }
-      )
-      res.status(StatusCodes.OK).json(transformGooglePlaceToSchema(data))
-    } else {
-      throw new CustomAPIError('Failed to fetch place from Google Places API', StatusCodes.INTERNAL_SERVER_ERROR)
-    }
-  }
-  res.status(StatusCodes.OK).json({ googlePlaceId })
-}
-
-export { fetchAllPlaces, fetchPlace, fetchAllNearbyPlaces, fetchGooglePlace }
+export { fetchAllPlaces, fetchPlace, fetchAllNearbyPlaces }

--- a/src/controllers/places.ts
+++ b/src/controllers/places.ts
@@ -22,7 +22,7 @@ const fetchPlace = async (req: Request, res: Response) => {
     placeId,
   })
     .select(
-      'placeId name state country imageURL address location type iconURL iconBackground summary reviewSummary rating userRatingCount'
+      'placeId name state country imageURL address location type iconURL iconBackground summary reviewSummary rating userRatingCount directionGoogleURI placeGoogleURI'
     )
     .lean()
 

--- a/src/controllers/places.ts
+++ b/src/controllers/places.ts
@@ -8,7 +8,7 @@ import CustomAPIError from '../errors/custom_error'
 import { v2 as cloudinary } from 'cloudinary'
 
 const PLACES_MAX_LIMIT = 50
-const GOOGLE_PLACE_FETCH_VERSION = 4
+const GOOGLE_PLACE_FETCH_VERSION = 5
 const PLACE_IMG_UPLOAD_MAX_COUNT = 1
 
 const fetchAllPlaces = async (req: Request, res: Response) => {
@@ -45,7 +45,7 @@ const fetchPlace = async (req: Request, res: Response) => {
       if (!apiKey)
         throw new CustomAPIError('Google Places API key is not configured', StatusCodes.INTERNAL_SERVER_ERROR)
       const fields =
-        'id,displayName,shortFormattedAddress,formattedAddress,addressComponents,location,icon_mask_base_uri,photos,primaryType,iconBackgroundColor,editorialSummary,generativeSummary,reviewSummary,rating,userRatingCount'
+        'id,displayName,shortFormattedAddress,formattedAddress,addressComponents,location,icon_mask_base_uri,photos,primaryType,iconBackgroundColor,editorialSummary,generativeSummary,reviewSummary,rating,userRatingCount,googleMapsLinks'
       const url = `https://places.googleapis.com/v1/places/${placeId}?fields=${fields}&key=${apiKey}`
 
       const response = await fetch(url)

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -113,7 +113,9 @@ const fetchPlan = async (req: Request, res: Response) => {
   const unorderedPlaces = await PlaceSchema.find({
     placeId: { $in: placeIds },
   })
-    .select('placeId name state country address summary imageURL location type rating userRatingCount reviewSummary')
+    .select(
+      'placeId name state country address summary imageURL location type rating userRatingCount reviewSummary directionGoogleURI placeGoogleURI'
+    )
     .lean()
 
   // Make sure the order of places is the same as plan.stops

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -6,6 +6,7 @@ import BookmarkSchema from '../models/Bookmarks'
 import UserSchema, { IUser } from '../models/Users'
 import NotFoundError from '../errors/not_found'
 import { geoJsonToCoords } from '../utils/location'
+import { attachBookmarkFlagToPlans } from './util'
 
 const PAGE_SIZE = 10
 const PLANS_MAX_LIMIT = 40
@@ -144,32 +145,6 @@ const fetchPlan = async (req: Request, res: Response) => {
     startLocation: geoJsonToCoords(plan?.startLocation),
     finishLocation: geoJsonToCoords(plan?.finishLocation),
   })
-}
-
-const attachBookmarkFlagToPlans = async (plans: IPlan[], userId: string) => {
-  if (!userId)
-    return plans.map((plan) => ({
-      ...plan,
-      isBookmarked: false,
-    }))
-
-  // Extract only plan IDs
-  const planIds = plans.map((plan) => plan._id)
-
-  // Get plan IDs from bookmarks collection based on userId
-  const bookmarks = await BookmarkSchema.find({
-    userId,
-    planId: { $in: planIds },
-  }).select('planId')
-
-  // Create a Set for fast lookup
-  const bookmarkedPlanIds = new Set(bookmarks.map((b) => b.planId.toString()))
-
-  // Attach isBookmarked state to each plan
-  return plans.map((plan) => ({
-    ...plan,
-    isBookmarked: bookmarkedPlanIds.has(plan._id.toString()),
-  }))
 }
 
 const fetchAllNearbyPlans = async (req: Request, res: Response) => {

--- a/src/controllers/util.ts
+++ b/src/controllers/util.ts
@@ -1,0 +1,28 @@
+import { IPlan } from '../models/Plans'
+import BookmarkSchema from '../models/Bookmarks'
+
+export const attachBookmarkFlagToPlans = async (plans: IPlan[], userId: string) => {
+  if (!userId)
+    return plans.map((plan) => ({
+      ...plan,
+      isBookmarked: false,
+    }))
+
+  // Extract only plan IDs
+  const planIds = plans.map((plan) => plan._id)
+
+  // Get plan IDs from bookmarks collection based on userId
+  const bookmarks = await BookmarkSchema.find({
+    userId,
+    planId: { $in: planIds },
+  }).select('planId')
+
+  // Create a Set for fast lookup
+  const bookmarkedPlanIds = new Set(bookmarks.map((b) => b.planId.toString()))
+
+  // Attach isBookmarked state to each plan
+  return plans.map((plan) => ({
+    ...plan,
+    isBookmarked: bookmarkedPlanIds.has(plan._id.toString()),
+  }))
+}

--- a/src/models/Lists.ts
+++ b/src/models/Lists.ts
@@ -1,0 +1,32 @@
+import mongoose, { Schema, Document, Types } from 'mongoose'
+
+export interface IList extends Document {
+  userId: Types.ObjectId
+  name: string
+  places: string[]
+  createdAt?: Date
+  updatedAt?: Date
+}
+
+const ListSchema: Schema<IList> = new Schema(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: [true, 'Provide user'],
+    },
+    name: {
+      type: String,
+      required: [true, 'Provide list name'],
+    },
+    places: {
+      type: [String],
+      default: [],
+    },
+  },
+  {
+    timestamps: true,
+  }
+)
+
+export default mongoose.model<IList>('List', ListSchema)

--- a/src/models/Places.ts
+++ b/src/models/Places.ts
@@ -18,6 +18,8 @@ export interface IPlace extends Document {
   reviewSummary: string // reviewSummary.text.text
   rating: number // rating
   userRatingCount: number // userRatingCount
+  directionGoogleURI?: string
+  placeGoogleURI?: string
   createdAt?: Date
   updatedAt?: Date
 }
@@ -100,6 +102,12 @@ const PlaceSchema: Schema<IPlace> = new Schema(
     userRatingCount: {
       type: Number,
       default: 0,
+    },
+    directionGoogleURI: {
+      type: String,
+    },
+    placeGoogleURI: {
+      type: String,
     },
   },
   {

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -9,9 +9,20 @@ import {
   addBookmark,
   removeBookmark,
 } from '../controllers/account'
+import {
+  fetchLists,
+  fetchAList,
+  createNewList,
+  removeList,
+  addPlaceToList,
+  removePlaceFromList,
+} from '../controllers/account/lists'
 
 const router = express.Router()
 
+router.route('/list').get(fetchLists).post(createNewList)
+router.route('/list/:listId').get(fetchAList).delete(removeList)
+router.route('/list/:listId/:placeId').post(addPlaceToList).delete(removePlaceFromList)
 router.route('/plans/').get(fetchAllPlans).post(createNewPlan)
 router.route('/plans/:planId').get(fetchPlan).put(updatePlan).delete(deletePlan)
 router.route('/bookmarks').get(fetchAllBookmarkedPlans)

--- a/src/routes/allNearby.ts
+++ b/src/routes/allNearby.ts
@@ -1,0 +1,8 @@
+import express from 'express'
+import { fetchAllNearby } from '../controllers/allNearby'
+
+const router = express.Router()
+
+router.route('/').get(fetchAllNearby)
+
+export default router

--- a/src/routes/places.ts
+++ b/src/routes/places.ts
@@ -1,12 +1,11 @@
 import express from 'express'
-import { fetchAllPlaces, fetchPlace, fetchAllNearbyPlaces, fetchGooglePlace } from '../controllers/places'
+import { fetchAllPlaces, fetchPlace, fetchAllNearbyPlaces } from '../controllers/places'
 
 const router = express.Router()
 
 router.route('/').get(fetchAllPlaces)
 // Specific routes first
 router.route('/nearby').get(fetchAllNearbyPlaces)
-router.route('/fetch/:googlePlaceId').get(fetchGooglePlace)
 
 // Generic route last to avoid conflicts
 router.route('/:placeId').get(fetchPlace)

--- a/src/utils/googlePlace.ts
+++ b/src/utils/googlePlace.ts
@@ -29,6 +29,7 @@ type GooglePlace = {
   }
   rating: number
   userRatingCount: number
+  googleMapsLinks: Links
 }
 
 type AddressComponents = {
@@ -40,6 +41,11 @@ type AddressComponents = {
 type Photo = {
   imageURL?: string
   name: string
+}
+
+type Links = {
+  directionsUri: string
+  placeUri: string
 }
 
 export const transformGooglePlaceToSchema = (data: GooglePlace) => {
@@ -88,6 +94,12 @@ export const transformGooglePlaceToSchema = (data: GooglePlace) => {
   // Get User Rating Count
   const userRatingCount = Number(data.userRatingCount || '0')
 
+  // Get GoogleMap Direction URI
+  const directionGoogleURI = data.googleMapsLinks?.directionsUri || ''
+
+  // Get GoogleMap Place URI
+  const placeGoogleURI = data.googleMapsLinks?.placeUri || ''
+
   return {
     placeId: data.id,
     name,
@@ -103,6 +115,8 @@ export const transformGooglePlaceToSchema = (data: GooglePlace) => {
     reviewSummary,
     rating,
     userRatingCount,
+    directionGoogleURI,
+    placeGoogleURI,
   }
 }
 


### PR DESCRIPTION
- Combine `/places/fetch/:placeId` into `/places/:placeId` route, So whenever it called just check the `places` collection if doesn't exist fetch from Google Places API
- Create a new route `/app` to fetch all nearby plans and places together based on geospatial boundary, could use to show all data in a single map.
- Create `List` modal schema all the related API routes to work with lists, The main purpose is to give each users ability to create lists and save places for later use, specially in create plan page.
- Fetch more property of places from Google Places API (Direction and Place's URIs)