### PR TITLE
Direction Encoded Polyline

### DIFF
--- a/src/controllers/account/account.ts
+++ b/src/controllers/account/account.ts
@@ -137,6 +137,7 @@ const fetchPlan = async (req: Request, res: Response) => {
         cities: 1,
         stopCount: 1,
         stops: 1,
+        polyline: 1,
         type: 1,
         rate: 1,
         reviewCount: 1,

--- a/src/controllers/account/direction.ts
+++ b/src/controllers/account/direction.ts
@@ -19,6 +19,12 @@ const updateDirection = async (req: Request, res: Response) => {
 
   if (!direction) throw new CustomAPIError('Unable to fetch direction', StatusCodes.INTERNAL_SERVER_ERROR)
 
+  // Update plan with direction details
+  plan.polyline = direction.polyline
+  plan.distance = Math.floor(direction.distanceMeters / 16.0934) / 100 // convert meters to miles with two decimals
+  plan.duration = Math.floor(direction.durationSeconds / 36) / 100 + plan.stopCount // Convert seconds to hours + one hour for each stops
+  await plan.save()
+
   res.status(StatusCodes.OK).json(direction)
 }
 

--- a/src/controllers/account/direction.ts
+++ b/src/controllers/account/direction.ts
@@ -1,0 +1,25 @@
+import { Response, Request } from 'express'
+import { StatusCodes } from 'http-status-codes'
+import CustomAPIError from '../../errors/custom_error'
+import { fetchDirection } from '../../utils/googlePlace'
+import PlanSchema, { IPlan } from '../../models/Plans'
+
+const updateDirection = async (req: Request, res: Response) => {
+  const { planId } = req.params
+  if (!planId) throw new CustomAPIError('Provide plan id', StatusCodes.BAD_REQUEST)
+
+  const plan: IPlan | null = await PlanSchema.findById(planId)
+  if (!plan) throw new CustomAPIError('Plan not found', StatusCodes.NOT_FOUND)
+
+  if (plan.stops.length < 2) throw new CustomAPIError('Plan should have at least 2 stops', StatusCodes.BAD_REQUEST)
+
+  const stopsLocation = plan.stops.map((s) => s.location)
+
+  const direction = await fetchDirection(stopsLocation)
+
+  if (!direction) throw new CustomAPIError('Unable to fetch direction', StatusCodes.INTERNAL_SERVER_ERROR)
+
+  res.status(StatusCodes.OK).json(direction)
+}
+
+export { updateDirection }

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -102,7 +102,7 @@ const fetchPlan = async (req: Request, res: Response) => {
   const plan: IPlan | null = await PlanSchema.findById(planId)
     .orFail(new NotFoundError(`Item not found with the id: ${planId}`))
     .select(
-      'title description images cities stopCount stops type rate reviewCount startLocation finishLocation distance duration createdAt updatedAt'
+      'title description images cities stopCount stops polyline type rate reviewCount startLocation finishLocation distance duration createdAt updatedAt'
     )
     .populate('userId', 'name imageURL')
     .lean()

--- a/src/models/Plans.ts
+++ b/src/models/Plans.ts
@@ -7,7 +7,7 @@ export interface IPlanStop {
   description?: string
   imageURL: string
   address: string
-  location: [number]
+  location: [number, number]
 }
 
 interface ICityRef {
@@ -24,6 +24,7 @@ export interface IPlan extends Document {
   cities: ICityRef[]
   stopCount: number
   stops: IPlanStop[]
+  polyline: string
   rate: number
   reviewCount: number
   startLocation?: {
@@ -123,6 +124,10 @@ const PlanSchema: Schema<IPlan> = new Schema(
         type: stopSchema,
       },
     ],
+    polyline: {
+      type: String,
+      default: '',
+    },
     rate: {
       type: Number,
       default: 0,

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -17,6 +17,7 @@ import {
   addPlaceToList,
   removePlaceFromList,
 } from '../controllers/account/lists'
+import { updateDirection } from '../controllers/account/direction'
 
 const router = express.Router()
 
@@ -25,6 +26,7 @@ router.route('/list/:listId').get(fetchAList).post(addPlaceToList).delete(remove
 router.route('/list/:listId/:placeId').delete(removePlaceFromList)
 router.route('/plans/').get(fetchAllPlans).post(createNewPlan)
 router.route('/plans/:planId').get(fetchPlan).put(updatePlan).delete(deletePlan)
+router.route('/plans/:planId/direction').get(updateDirection)
 router.route('/bookmarks').get(fetchAllBookmarkedPlans)
 router.route('/bookmarks/:planId').post(addBookmark).delete(removeBookmark)
 

--- a/src/utils/googlePlace.ts
+++ b/src/utils/googlePlace.ts
@@ -209,7 +209,7 @@ export const fetchDirection = async (points: [number, number][]): Promise<Direct
     },
     ...(intermediates.length && { intermediates }),
     travelMode: 'WALK',
-    polylineQuality: 'overview',
+    polylineQuality: 'OVERVIEW',
     routingPreference: 'ROUTING_PREFERENCE_UNSPECIFIED',
     computeAlternativeRoutes: false,
     // routeModifiers: {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds walking directions and encoded polyline generation for Plans, using Google Routes API. Also returns the polyline in plan fetch responses.

- **New Features**
  - GET /account/plans/:planId/direction computes and persists route details.
  - Integrates Google Routes API to return distanceMeters, durationSeconds, and encoded polyline.
  - Saves Plan.polyline, converts distance to miles, and calculates duration; requires at least 2 stops.
  - Fetch Plan endpoints now include polyline.

- **Migration**
  - PlanStop.location updated to [lat, lng]; migrate existing documents.
  - Set GOOGLE_MAPS_API_KEY in environment.

<sup>Written for commit 7717807a9e28ba4436edd4321659775d92a95da5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



