### PR TITLE
Add Note and Expense to each Stops in Plan Detail

### DIFF
--- a/src/controllers/account/account.ts
+++ b/src/controllers/account/account.ts
@@ -9,11 +9,11 @@ import UnauthenticatedError from '../../errors/unauthentication_error'
 import { coordsToGeoJson, geoJsonToCoords } from '../../utils/location'
 import CitySchema, { ICity } from '../../models/Cities'
 
-type PlaceDTO = Omit<IPlace, 'location' | 'createdAt' | 'updatedAt'> & {
+type IPlaceDTO = Omit<IPlace, 'location' | 'createdAt' | 'updatedAt'> & {
   location: [number, number]
 }
 
-type CityDTO = Omit<ICity, 'imageURL' | 'location' | 'plans' | 'createdAt' | 'updatedAt'>
+type ICityDTO = Omit<ICity, 'imageURL' | 'location' | 'plans' | 'createdAt' | 'updatedAt'>
 
 const PAGE_SIZE = 10
 
@@ -61,7 +61,7 @@ const createNewPlan = async (req: Request, res: Response) => {
   // Insert cities in Cities collection if placeId does not exist
   // Increment plan's count in Cities Collection if placeId exist
   if (cities && cities.length > 0) {
-    const ops = cities.map((city: CityDTO) => ({
+    const ops = cities.map((city: ICityDTO) => ({
       updateOne: {
         filter: { placeId: city.placeId },
         update: {
@@ -81,7 +81,7 @@ const createNewPlan = async (req: Request, res: Response) => {
 
   if (stops && stops.length > 0) {
     // Insert stops in Places collection if id does not exist
-    const ops = stops.map((stop: PlaceDTO) => ({
+    const ops = stops.map((stop: IPlaceDTO) => ({
       updateOne: {
         filter: { placeId: stop.placeId },
         update: {
@@ -191,7 +191,7 @@ const updatePlan = async (req: Request, res: Response) => {
 
   if (stops) {
     // Insert stops in Places collection if id does not exist
-    const ops = stops.map((stop: PlaceDTO) => ({
+    const ops = stops.map((stop: IPlaceDTO) => ({
       updateOne: {
         filter: { placeId: stop.placeId },
         update: {

--- a/src/controllers/account/account.ts
+++ b/src/controllers/account/account.ts
@@ -160,17 +160,15 @@ const fetchPlan = async (req: Request, res: Response) => {
   const unorderedPlaces = await PlaceSchema.find({
     placeId: { $in: placeIds },
   })
-    .select(
-      'placeId name state country address summary imageURL location type rating userRatingCount reviewSummary directionGoogleURI placeGoogleURI'
-    )
+    .select('placeId state country summary type rating userRatingCount reviewSummary directionGoogleURI placeGoogleURI')
     .lean()
 
   // Make sure the order of places is the same as plan.stops
   const places = plan?.stops.map((stop) => {
-    const res = unorderedPlaces.find((place) => stop.placeId === place.placeId)
+    const placeDetail = unorderedPlaces.find((place) => stop.placeId === place.placeId)
     return {
-      ...res,
-      location: geoJsonToCoords(res?.location),
+      ...stop,
+      ...placeDetail,
     }
   })
 

--- a/src/controllers/account/fixme_util.ts
+++ b/src/controllers/account/fixme_util.ts
@@ -1,0 +1,52 @@
+import { IPlan } from '../../models/Plans'
+import { geoJsonToCoords } from '../../utils/location'
+import PlaceSchema from '../../models/Places'
+import CitySchema from '../../models/Cities'
+
+// FIXME: Use ref in plan schema to reference cities to City and stops to Place collection and use the ref to populate instead of this below logic
+
+export default async function fixme_populatePlan(plan: IPlan) {
+  // Get all cityIDs of stops in an array
+  const cityIds = plan.cities.map((c) => c.placeId)
+  // Select all cities by the ids
+  const unorderedCities = await CitySchema.find({
+    placeId: { $in: cityIds },
+  })
+    .select('placeId name state country imageURL location viewport plans')
+    .lean()
+
+  // Make sure the order of cities is the same as plan.cities
+  const cities = plan.cities.map((city) => {
+    const res = unorderedCities.find((c) => city.placeId === c.placeId)
+    return {
+      ...res,
+      location: geoJsonToCoords(res?.location),
+    }
+  })
+
+  // Get all placeIDs of stops in an array
+  const placeIds = plan.stops.map((stop) => stop.placeId)
+  // Select all places by the ids
+  const unorderedPlaces = await PlaceSchema.find({
+    placeId: { $in: placeIds },
+  })
+    .select('placeId state country summary type rating userRatingCount reviewSummary directionGoogleURI placeGoogleURI')
+    .lean()
+
+  // Make sure the order of places is the same as plan.stops
+  const places = plan.stops.map((stop) => {
+    const placeDetail = unorderedPlaces.find((place) => stop.placeId === place.placeId)
+    return {
+      ...stop,
+      ...placeDetail,
+    }
+  })
+
+  return {
+    ...plan,
+    cities: cities,
+    stops: places,
+    startLocation: geoJsonToCoords(plan.startLocation),
+    finishLocation: geoJsonToCoords(plan.finishLocation),
+  }
+}

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -134,17 +134,15 @@ const fetchPlan = async (req: Request, res: Response) => {
   const unorderedPlaces = await PlaceSchema.find({
     placeId: { $in: placeIds },
   })
-    .select(
-      'placeId name state country address summary imageURL location type rating userRatingCount reviewSummary directionGoogleURI placeGoogleURI'
-    )
+    .select('placeId state country summary type rating userRatingCount reviewSummary directionGoogleURI placeGoogleURI')
     .lean()
 
   // Make sure the order of places is the same as plan.stops
   const places = plan?.stops.map((stop) => {
-    const res = unorderedPlaces.find((place) => stop.placeId === place.placeId)
+    const placeDetail = unorderedPlaces.find((place) => stop.placeId === place.placeId)
     return {
-      ...res,
-      location: geoJsonToCoords(res?.location),
+      ...stop,
+      ...placeDetail,
     }
   })
 

--- a/src/models/Plans.ts
+++ b/src/models/Plans.ts
@@ -4,7 +4,8 @@ import './Users'
 export interface IPlanStop {
   placeId: string
   name: string
-  description?: string
+  note?: string
+  expense?: number
   imageURL: string
   address: string
   location: [number, number]
@@ -61,7 +62,7 @@ const pointSchema = new mongoose.Schema({
   },
 })
 
-export const stopSchema = new mongoose.Schema({
+export const stopSchema: Schema<IPlanStop> = new Schema({
   placeId: {
     type: String,
     required: [true, 'Provide place ID'],
@@ -71,20 +72,12 @@ export const stopSchema = new mongoose.Schema({
     type: String,
     required: [true, 'Provide place name'],
   },
-  description: String,
+  note: String,
   imageURL: String,
   address: String,
   location: {
     type: [Number, Number],
     required: [true, 'Provide location coordinates for each stop'],
-  },
-  rating: {
-    type: Number,
-    default: 0,
-  },
-  userRatingCount: {
-    type: Number,
-    default: 0,
   },
 })
 

--- a/src/models/Plans.ts
+++ b/src/models/Plans.ts
@@ -11,7 +11,7 @@ export interface IPlanStop {
   location: [number, number]
 }
 
-interface ICityRef {
+export interface IPlanCity {
   placeId: string
   name: string
 }
@@ -22,7 +22,7 @@ export interface IPlan extends Document {
   description?: string
   images: string[]
   type?: 'Full day' | 'Half day' | 'Night'
-  cities: ICityRef[]
+  cities: IPlanCity[]
   stopCount: number
   stops: IPlanStop[]
   polyline: string
@@ -42,7 +42,7 @@ export interface IPlan extends Document {
   updatedAt?: Date
 }
 
-const CitySchema = new mongoose.Schema<ICityRef>(
+const CitySchema = new mongoose.Schema<IPlanCity>(
   {
     placeId: { type: String, required: true },
     name: { type: String, required: true },
@@ -72,7 +72,14 @@ export const stopSchema: Schema<IPlanStop> = new Schema({
     type: String,
     required: [true, 'Provide place name'],
   },
-  note: String,
+  note: {
+    type: String,
+    default: '',
+  },
+  expense: {
+    type: Number,
+    default: 0,
+  },
   imageURL: String,
   address: String,
   location: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added note and expense to each plan stop. Fetch and update now return populated city and stop details with correct order and normalized start/finish locations.

- **Migration**
  - Replace stop.description with stop.note.
  - Send stop.expense (number). Defaults to 0 if omitted.

<sup>Written for commit 05da21a1aee7376a20fe028f8653ff07ec7003ad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

