### PR TITLE
Auth Token Expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,6 @@ MONGO_URI=your-mongodb-uri
 # JWT Settings
 JWT_SECRET_KEY=unique-jwt-secret-key
 JWT_LIFETIME=1d
-JWT_EXPIRES_IN=3600
 NODE_ENV=development
 
 # SMTP & SendGrid Settings

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ MONGO_URI="your-mongodb-uri"
 # JWT Settings
 JWT_SECRET_KEY="unique-jwt-secret-key"
 JWT_LIFETIME="1d"
-JWT_EXPIRES_IN="3600"
 NODE_ENV="development"
 # SMTP & SendGrid Settings
 SMTP_HOST="smtp.sendgrid.net"

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -552,7 +552,7 @@ paths:
                   "email": "bob@example.com",
                   "imageURL": "http://example.com/bob.jpg",
                   "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw",
-                  "expiresIn": "1d"
+                  "expiresIn": "Sat, 08 Nov 2025 04:42:04 GMT"
                 }
           headers: {}
       deprecated: false
@@ -588,7 +588,7 @@ paths:
                   "email": "bob@example.com",
                   "imageURL": "http://example.com/bob.jpg",
                   "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw",
-                  "expiresIn": "1d"
+                  "expiresIn": "Sat, 08 Nov 2025 04:42:04 GMT"
                 }
           headers: {}
       deprecated: false
@@ -647,7 +647,7 @@ paths:
                   "email": "bob@example.com",
                   "imageURL": "http://example.com/bob.jpg",
                   "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw",
-                  "expiresIn": "1d"
+                  "expiresIn": "Sat, 08 Nov 2025 04:42:04 GMT"
                 }
           headers: {}
       deprecated: false 

--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -551,7 +551,8 @@ paths:
                   "name": "Bob",
                   "email": "bob@example.com",
                   "imageURL": "http://example.com/bob.jpg",
-                  "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw"
+                  "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw",
+                  "expiresIn": "1d"
                 }
           headers: {}
       deprecated: false
@@ -586,7 +587,8 @@ paths:
                   "name": "Bob",
                   "email": "bob@example.com",
                   "imageURL": "http://example.com/bob.jpg",
-                  "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw"
+                  "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw",
+                  "expiresIn": "1d"
                 }
           headers: {}
       deprecated: false
@@ -644,7 +646,8 @@ paths:
                   "name": "Bob",
                   "email": "bob@example.com",
                   "imageURL": "http://example.com/bob.jpg",
-                  "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw"
+                  "token": "example-token-sdf98sdf879sdf9sd8fsd89f89wefw",
+                  "expiresIn": "1d"
                 }
           headers: {}
       deprecated: false 

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -55,13 +55,7 @@ const login = async (req: Request, res: Response): Promise<void> => {
 
   // generate JWT token and response.
   const token = user.createJWT()
-  const expiresIn = process.env.JWT_EXPIRES_IN || 3000
-  res.cookie('token', token, {
-    maxAge: parseInt(`${expiresIn}`) * 1000,
-    httpOnly: true,
-    secure: process.env.NODE_ENV == 'production',
-    sameSite: 'strict',
-  })
+
   res.status(StatusCodes.OK).json({
     _id: user._id,
     name: user.name,

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -25,7 +25,7 @@ const register = async (req: Request<object, object, RegisterRequestBody>, res: 
   })
   await user.save()
 
-  const token = user.createJWT()
+  const { token, expiresIn } = user.createJWT()
 
   res.status(StatusCodes.CREATED).json({
     _id: user._id,
@@ -33,6 +33,7 @@ const register = async (req: Request<object, object, RegisterRequestBody>, res: 
     email: user.email,
     imageURL: user.imageURL,
     token,
+    expiresIn,
   })
 }
 
@@ -54,7 +55,7 @@ const login = async (req: Request, res: Response): Promise<void> => {
   }
 
   // generate JWT token and response.
-  const token = user.createJWT()
+  const { token, expiresIn } = user.createJWT()
 
   res.status(StatusCodes.OK).json({
     _id: user._id,
@@ -62,6 +63,7 @@ const login = async (req: Request, res: Response): Promise<void> => {
     email: user.email,
     imageURL: user.imageURL,
     token,
+    expiresIn,
   })
 }
 
@@ -129,13 +131,14 @@ const resetPassword = async (req: Request, res: Response) => {
   user.passwordResetExpires = undefined
 
   await user.save()
-  const token = user.createJWT()
+  const { token, expiresIn } = user.createJWT()
   res.status(StatusCodes.OK).json({
     _id: user._id,
     name: user.name,
     email: user.email,
     imageURL: user.imageURL,
     token,
+    expiresIn,
   })
 }
 

--- a/src/controllers/oauth.ts
+++ b/src/controllers/oauth.ts
@@ -44,13 +44,7 @@ const googleLogin = async (req: Request, res: Response): Promise<void> => {
 
   // generate JWT token and response.
   const token = user.createJWT()
-  const expiresIn = process.env.JWT_EXPIRES_IN || 3000
-  res.cookie('token', token, {
-    maxAge: parseInt(`${expiresIn}`) * 1000,
-    httpOnly: true,
-    secure: process.env.NODE_ENV == 'production',
-    sameSite: 'strict',
-  })
+
   res.status(StatusCodes.OK).json({
     _id: user._id,
     name: user.name,

--- a/src/controllers/oauth.ts
+++ b/src/controllers/oauth.ts
@@ -43,7 +43,7 @@ const googleLogin = async (req: Request, res: Response): Promise<void> => {
   }
 
   // generate JWT token and response.
-  const token = user.createJWT()
+  const { token, expiresIn } = user.createJWT()
 
   res.status(StatusCodes.OK).json({
     _id: user._id,
@@ -51,6 +51,7 @@ const googleLogin = async (req: Request, res: Response): Promise<void> => {
     email: user.email,
     imageURL: user.imageURL,
     token,
+    expiresIn,
   })
 }
 

--- a/src/models/Users.ts
+++ b/src/models/Users.ts
@@ -79,11 +79,7 @@ UserSchema.methods.createJWT = function (): string {
   if (!secretKey) {
     throw new Error('JWT_SECRET_KEY is not defined in the environment variable.')
   }
-  // previous code with error
-  // const expiresIn = process.env.JWT_LIFETIME ? parseInt(process.env.JWT_LIFETIME) : 3600 // Default to 1 hour (3600 seconds)
-  // const options: SignOptions = {
-  //   expiresIn,
-  // }
+
   const expiresIn = process.env.JWT_LIFETIME || '1d'
   const options: SignOptions = {
     expiresIn: expiresIn as SignOptions['expiresIn'],

--- a/src/models/Users.ts
+++ b/src/models/Users.ts
@@ -11,7 +11,7 @@ export interface IUser extends Document {
   passwordResetExpires?: number
   createdAt?: Date
   updatedAt?: Date
-  createJWT(): string
+  createJWT(): { token: string; expiresIn: string }
   comparePassword(userPassword: string): Promise<boolean>
 }
 
@@ -74,7 +74,7 @@ UserSchema.pre<IUser>('save', async function (next) {
 })
 
 // create JWT token method
-UserSchema.methods.createJWT = function (): string {
+UserSchema.methods.createJWT = function (): { token: string; expiresIn: string } {
   const secretKey = process.env.JWT_SECRET_KEY as string // Explicit cast to string
   if (!secretKey) {
     throw new Error('JWT_SECRET_KEY is not defined in the environment variable.')
@@ -85,7 +85,7 @@ UserSchema.methods.createJWT = function (): string {
     expiresIn: expiresIn as SignOptions['expiresIn'],
   }
 
-  return jwt.sign({ userId: this._id, name: this.name }, secretKey, options)
+  return { token: jwt.sign({ userId: this._id, name: this.name }, secretKey, options), expiresIn: expiresIn }
 }
 
 // compare password method

--- a/src/models/Users.ts
+++ b/src/models/Users.ts
@@ -1,6 +1,7 @@
 import mongoose, { Document, Schema } from 'mongoose'
 import bcrypt from 'bcryptjs'
 import jwt, { SignOptions } from 'jsonwebtoken'
+import { parseMs } from '../utils/ms'
 
 export interface IUser extends Document {
   name: string
@@ -85,7 +86,10 @@ UserSchema.methods.createJWT = function (): { token: string; expiresIn: string }
     expiresIn: expiresIn as SignOptions['expiresIn'],
   }
 
-  return { token: jwt.sign({ userId: this._id, name: this.name }, secretKey, options), expiresIn: expiresIn }
+  return {
+    token: jwt.sign({ userId: this._id, name: this.name }, secretKey, options),
+    expiresIn: new Date(Date.now() + parseMs(expiresIn)).toUTCString(),
+  }
 }
 
 // compare password method

--- a/src/utils/ms.ts
+++ b/src/utils/ms.ts
@@ -1,0 +1,101 @@
+// Helpers.
+const s = 1000
+const m = s * 60
+const h = m * 60
+const d = h * 24
+const w = d * 7
+const y = d * 365.25
+
+type Unit =
+  | 'Years'
+  | 'Year'
+  | 'Yrs'
+  | 'Yr'
+  | 'Y'
+  | 'Weeks'
+  | 'Week'
+  | 'W'
+  | 'Days'
+  | 'Day'
+  | 'D'
+  | 'Hours'
+  | 'Hour'
+  | 'Hrs'
+  | 'Hr'
+  | 'H'
+  | 'Minutes'
+  | 'Minute'
+  | 'Mins'
+  | 'Min'
+  | 'M'
+  | 'Seconds'
+  | 'Second'
+  | 'Secs'
+  | 'Sec'
+  | 's'
+  | 'Milliseconds'
+  | 'Millisecond'
+  | 'Msecs'
+  | 'Msec'
+  | 'Ms'
+
+export function parseMs(str: string): number {
+  if (typeof str !== 'string' || str.length === 0 || str.length > 100) {
+    throw new Error('Value provided to parseMs() must be a string with length between 1 and 99.')
+  }
+  const match =
+    /^(?<value>-?(?:\d+)?\.?\d+) *(?<type>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+      str
+    )
+  // Named capture groups need to be manually typed today.
+  // https://github.com/microsoft/TypeScript/issues/32098
+  const groups = match?.groups as { value: string; type?: string } | undefined
+  if (!groups) {
+    return NaN
+  }
+  const n = parseFloat(groups.value)
+  const type = (groups.type || 'ms').toLowerCase() as Lowercase<Unit>
+  switch (type) {
+    case 'years':
+    case 'year':
+    case 'yrs':
+    case 'yr':
+    case 'y':
+      return n * y
+    case 'weeks':
+    case 'week':
+    case 'w':
+      return n * w
+    case 'days':
+    case 'day':
+    case 'd':
+      return n * d
+    case 'hours':
+    case 'hour':
+    case 'hrs':
+    case 'hr':
+    case 'h':
+      return n * h
+    case 'minutes':
+    case 'minute':
+    case 'mins':
+    case 'min':
+    case 'm':
+      return n * m
+    case 'seconds':
+    case 'second':
+    case 'secs':
+    case 'sec':
+    case 's':
+      return n * s
+    case 'milliseconds':
+    case 'millisecond':
+    case 'msecs':
+    case 'msec':
+    case 'ms':
+      return n
+    default:
+      // This should never occur.
+      throw new Error(`The unit ${type as string} was matched, but no matching case exists.`)
+  }
+}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add explicit token expiration to auth responses and remove cookie-based token handling so clients manage token storage and expiry themselves. Swagger now documents expiresIn, and JWT_EXPIRES_IN is removed in favor of JWT_LIFETIME.

- **New Features**
  - Auth endpoints return token and expiresIn (UTC datetime).
  - Token expiry derives from JWT_LIFETIME (e.g., "1d") via new parseMs utility.
  - Updated Swagger examples to include expiresIn.

- **Migration**
  - No more auth token cookies; store the token client-side and use expiresIn to handle expiry.
  - Remove JWT_EXPIRES_IN from environment; use JWT_LIFETIME instead.

<sup>Written for commit cc9f055fd031fbd2e2ad8e8f5b33a2a2e35937a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



