### PR TITLE
Switch Google OAuth Token Code to Credential

### DIFF
--- a/src/controllers/oauth.ts
+++ b/src/controllers/oauth.ts
@@ -20,7 +20,7 @@ const googleLogin = async (req: Request, res: Response): Promise<void> => {
   })
 
   const payload = ticket.getPayload()
-  if (!payload) throw new UnauthenticatedError('Invalid token.')
+  if (!payload || !payload.email) throw new UnauthenticatedError('Invalid token.')
 
   let user: IUser | null = await UserSchema.findOne({ email: payload.email })
   if (!user) {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch Google login to verify the Google credential (ID token) directly instead of exchanging an auth code. This simplifies the flow and removes the extra userinfo request.

- **Refactors**
  - Use OAuth2Client.verifyIdToken with the credential and client ID.
  - Remove getToken and fetch to Google userinfo; read profile from token payload.
  - Update error messages and variable names; keep user creation logic intact.

<sup>Written for commit c39456deae369374f46454c403b69eab2e1402bb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



