### PR TITLE
Store cors origins URLs in an env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,5 @@ CLOUDINARY_URL="cloudinary://<api_key>:<api_secret>@<cloud_name>"
 # Google OAuth2
 GOOGLE_OAUTH2_CLIENT_ID=""
 GOOGLE_OAUTH2_CLIENT_SECRET=""
+
+CORS_ORIGINS="URLS_SEPARATED_BY_COMMA"

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,8 @@ import errorHandlerMiddleware from './middlewares/errorHandlerMiddleware'
 import notFoundMiddleware from './middlewares/notFoundMiddleware'
 import path from 'path'
 import multer from 'multer'
+import { loadEnv } from './utils/loadEnv'
+loadEnv()
 
 const upload = multer({ storage: multer.memoryStorage() })
 const app = express()

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,12 +25,10 @@ const upload = multer({ storage: multer.memoryStorage() })
 const app = express()
 
 // middleware
+const corsOriginURLs = process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : '*'
 app.use(
   cors({
-    origin: [
-      'http://localhost:5173', // for local dev
-      'https://ziptrip.rezahedi.dev', // for production frontend
-    ],
+    origin: corsOriginURLs,
     credentials: true, // allow cookies / auth headers
     allowedHeaders: ['Content-Type', 'Authorization'], // needed for JWT
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], // safe list

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,7 @@ const upload = multer({ storage: multer.memoryStorage() })
 const app = express()
 
 // middleware
-const corsOriginURLs = process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : '*'
+const corsOriginURLs = process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : false
 app.use(
   cors({
     origin: corsOriginURLs,

--- a/src/middlewares/dbMiddleware.ts
+++ b/src/middlewares/dbMiddleware.ts
@@ -1,9 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { connectDB } from '../db/connection'
-import { loadEnv } from '../utils/loadEnv'
 import { StatusCodes } from 'http-status-codes'
 import CustomAPIError from '../errors/custom_error'
-loadEnv()
 
 const authMiddleware = async (request: Request, response: Response, next: NextFunction) => {
   if (!process.env.MONGO_URI) {

--- a/src/middlewares/dbMiddleware.ts
+++ b/src/middlewares/dbMiddleware.ts
@@ -3,7 +3,7 @@ import { connectDB } from '../db/connection'
 import { StatusCodes } from 'http-status-codes'
 import CustomAPIError from '../errors/custom_error'
 
-const authMiddleware = async (request: Request, response: Response, next: NextFunction) => {
+const dbMiddleware = async (request: Request, response: Response, next: NextFunction) => {
   if (!process.env.MONGO_URI) {
     throw new CustomAPIError(
       'Database connection string is undefined. Check your environment variables.',
@@ -15,4 +15,4 @@ const authMiddleware = async (request: Request, response: Response, next: NextFu
   next()
 }
 
-export default authMiddleware
+export default dbMiddleware


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make CORS origins configurable via the CORS_ORIGINS env var, so deployments can set allowed URLs without code changes. Load envs at app startup and fix the DB middleware name.

- **New Features**
  - Read CORS origins from CORS_ORIGINS (comma-separated).
  - Added CORS_ORIGINS to .env.example.
  - Fallback to same-origin only when not set.

- **Refactors**
  - Call loadEnv() once in app.ts.
  - Rename authMiddleware to dbMiddleware and remove loadEnv from the middleware.

<sup>Written for commit b3b4fef7cd176280ebb2b4d8bad7394b8cbd3c84. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



